### PR TITLE
support all paradox domains

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,11 +18,7 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "https://olivia.paradox.ai/*",
-        "https://stg.paradox.ai/*",
-        "https://www.mchire.com/*"
-      ],
+      "matches": ["https://*.paradox.ai/*", "https://www.mchire.com/*"],
       "css": ["css/content.css"],
       "js": ["content.js"]
     }
@@ -37,7 +33,7 @@
         "bootstrap/css/*",
         "bootstrap/js/*"
       ],
-      "matches": ["https://olivia.paradox.ai/*", "https://stg.paradox.ai/*"]
+      "matches": ["https://*.paradox.ai/*"]
     }
   ]
 }


### PR DESCRIPTION
I changed the URL pattern in the manifest to fit all paradox environments except of the special instances (such as mchire) which still need to be added one by one.

So now the extension works on:
dev
test
ltsstg
stg
prod

and mchire that was already there